### PR TITLE
Fix issues indicated by Lychee diagnostics output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN \
 	php7-zip \
 	re2c && \
  echo "**** install lychee ****" && \
- git clone https://github.com/LycheeOrg/Lychee /usr/share/webapps/lychee && \
+ git clone --recurse-submodules https://github.com/LycheeOrg/Lychee /usr/share/webapps/lychee && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/*

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -4,7 +4,7 @@
 mkdir -p \
 	/config/lychee
 
-for image_index in {big,import,medium,thumb}; do
+for image_index in {big,import,medium,small,thumb}; do
 if [ ! -f /pictures/${image_index}/index.html ]; then
 mkdir -p /pictures/${image_index}
 : > /pictures/${image_index}/index.html


### PR DESCRIPTION
After spinning up the image on an armhf board and connecting it to a
mysql database container, two issues were found by the Lychee
diagnostic output (reachable under Settings in the left sidebar):

- The Lychee frontend code is missing (ouch!)
- The folder for small thumbs is missing

After the fixes, with a rebuilt image the diagnostics finally report
the latest Lychee version (3.2.7) instead of an error message and the
error about missing upload folder is also gone, instead the below
confirmation is found:

"No critical problems found. Lychee should work without problems!"

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

